### PR TITLE
Declare "slack_channel" input in actions.yml

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -18,6 +18,9 @@ inputs:
   slack_bot_token:
     required: true
     description: Slack Bot Token
+  slack_channel:
+    required: true
+    description: Slack channel to send the announcement to
   project_logo:
     required: true
     description: Project logo

--- a/main.py
+++ b/main.py
@@ -69,6 +69,10 @@ def main(args: List[str]) -> None:
         }
     ]
 
+    channel = os.environ['INPUT_SLACK_CHANNEL']
+    if not channel.startswith("#"):
+        channel = f"#{channel}"
+
     try:
         response = client.chat_postMessage(
             channel=os.environ['INPUT_SLACK_CHANNEL'], 


### PR DESCRIPTION
Two small changes:

* Declare `slack_channel` input in `actions.yml`. This allow linters to do their job.
* Add `#` prefix is user didn't add one already to avoid small mistakes.