### PR TITLE
Convert Markdown links for Slack

### DIFF
--- a/main.py
+++ b/main.py
@@ -1,10 +1,21 @@
 import os
 import json
+from slackify_markdown import slackify_markdown
 from slack_sdk import WebClient
 from slack_sdk.errors import SlackApiError
 import sys
 from typing import List
 #from actions import io
+
+
+SLACK_SECTION_TEXT_LIMIT = 3000
+
+
+def format_release_notes(release_notes: str) -> str:
+    """Convert Markdown to Slack mrkdwn and enforce the section limit."""
+
+    formatted_notes = slackify_markdown(release_notes).rstrip("\n")
+    return formatted_notes[:SLACK_SECTION_TEXT_LIMIT]
 
 
 def main(args: List[str]) -> None:
@@ -62,7 +73,7 @@ def main(args: List[str]) -> None:
                     "type": "section",
                     "text": {
                         "type": "mrkdwn",
-                        "text": release_notes[0:3000]
+                        "text": format_release_notes(release_notes)
                     }
                 }
             ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 slack_sdk>=3.43.0
+slackify-markdown>=0.2.4,<0.3

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -1,0 +1,69 @@
+import unittest
+
+from main import format_release_notes
+
+
+class FormatReleaseNotesTests(unittest.TestCase):
+    def test_converts_openexr_release_note_to_slack_mrkdwn(self):
+        release_notes = (
+            "* **PyOpenEXR RGB-channel-coalescing bugs**\n"
+            "  * [CVE-2026-68514]"
+            "(https://www.cve.org/CVERecord?id=CVE-2026-68514) "
+            "PyOpenEXR heap buffer overflow"
+        )
+
+        self.assertEqual(
+            format_release_notes(release_notes),
+            (
+                "•   *PyOpenEXR RGB-channel-coalescing bugs*\n"
+                "    ◦   "
+                "<https://www.cve.org/CVERecord?id=CVE-2026-68514|"
+                "CVE-2026-68514> PyOpenEXR heap buffer overflow"
+            )
+        )
+
+    def test_converts_headings_emphasis_and_ordered_lists(self):
+        self.assertEqual(
+            format_release_notes(
+                "# Changes\n\n"
+                "1. **Bold**\n"
+                "2. *Italic* and ~~removed~~"
+            ),
+            (
+                "*Changes*\n\n"
+                "1.  *Bold*\n"
+                "2.  _Italic_ and ~removed~"
+            )
+        )
+
+    def test_preserves_code_and_converts_blockquotes(self):
+        release_notes = (
+            "> **Important**\n\n"
+            "`inline` and:\n\n"
+            "```python\n"
+            "print(\"**not bold**\")\n"
+            "```"
+        )
+
+        self.assertEqual(
+            format_release_notes(release_notes),
+            (
+                "> *Important*\n\n"
+                "`inline` and:\n\n"
+                "```\n"
+                "print(\"**not bold**\")\n"
+                "```"
+            )
+        )
+
+    def test_enforces_slack_section_text_limit_after_conversion(self):
+        release_notes = "[link](https://example.com) " + ("x" * 3000)
+
+        formatted_notes = format_release_notes(release_notes)
+
+        self.assertEqual(len(formatted_notes), 3000)
+        self.assertTrue(formatted_notes.startswith("<https://example.com|link>"))
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Translate GitHub-style release note links into Slack mrkdwn syntax while preserving the section text limit. The converts:

`[CVE-2026-68514](https://www.cve.org/CVERecord?id=CVE-2026-68514)`

to: 

`<https://www.cve.org/CVERecord?id=CVE-2026-68514|CVE-2026-68514>`

Without this, markdown links in release notes come through as verbatim text, not hyperlinks.

Assisted-by: Copilot GPT-5.6 Sol